### PR TITLE
feat: swap / useFake

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -1,0 +1,10 @@
+/*
+ * @japa/plugin-adonisjs
+ *
+ * (c) Japa
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+export { useFake } from './src/swap.ts'

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import { CookieClient } from '@adonisjs/core/http'
 import { Encryption } from '@adonisjs/core/encryption'
 import type { ApplicationService } from '@adonisjs/core/types'
 
+import { extendSwap } from './src/swap.ts'
 import { extendContext } from './src/extend_context.ts'
 import { verifyPrompts } from './src/verify_prompts.ts'
 
@@ -37,6 +38,8 @@ async function canImport(pkg: string) {
  */
 export function pluginAdonisJS(app: ApplicationService, options?: { baseURL: string }) {
   const pluginFn: PluginFn = async function ({ runner }) {
+    extendSwap(app.container)
+
     if (app.container.hasAllBindings(['router', 'repl'])) {
       extendContext(await app.container.make('router'), await app.container.make('repl'))
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "!build/tests_helpers"
   ],
   "exports": {
-    ".": "./build/index.js"
+    ".": "./build/index.js",
+    "./helpers": "./build/helpers.js"
   },
   "engines": {
     "node": ">=18.16.0"
@@ -95,7 +96,8 @@
   },
   "tsdown": {
     "entry": [
-      "./index.ts"
+      "./index.ts",
+      "./helpers.ts"
     ],
     "outDir": "./build",
     "clean": true,

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -10,6 +10,8 @@
 import { getActiveTest } from '@japa/runner'
 import { TestContext } from '@japa/runner/core'
 import type { Container } from '@adonisjs/core/container'
+import type { BindingResolver } from '@adonisjs/core/types/container'
+import { type AbstractConstructor } from '@adonisjs/core/types/common'
 
 import './types/extended.js'
 import debug from './debug.ts'
@@ -33,4 +35,31 @@ export function extendSwap(container: Container<any>) {
 
     return fake
   })
+}
+
+/**
+ * Swap a container binding with a fake implementation for the
+ * duration of the current test. The original binding is automatically
+ * restored after the test completes.
+ *
+ * Standalone version of `TestContext.swap` that can be called
+ * from anywhere within a running test
+ *
+ * @example
+ * ```ts
+ * import { useFake } from '@japa/plugin-adonisjs/helpers'
+ *
+ * function swapMailer() {
+ *   return useFake(Mailer, new FakeMailer())
+ * }
+ * ```
+ */
+export function useFake<Binding extends AbstractConstructor<any>>(
+  binding: Binding,
+  fake: InstanceType<Binding> | BindingResolver<any, InstanceType<Binding>>
+): InstanceType<Binding> {
+  const activeTest = getActiveTest()
+  if (!activeTest) throw new Error('Cannot use "useFake" outside of a Japa test')
+
+  return activeTest.context.swap(binding, fake)
 }

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -1,0 +1,36 @@
+/*
+ * @japa/plugin-adonisjs
+ *
+ * (c) Japa
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { getActiveTest } from '@japa/runner'
+import { TestContext } from '@japa/runner/core'
+import type { Container } from '@adonisjs/core/container'
+
+import './types/extended.js'
+import debug from './debug.ts'
+
+/**
+ * Extends the Japa test context with a `swap` method that allows
+ * replacing a container binding with a fake for the duration of the test.
+ *
+ * The original binding is automatically restored after the test completes.
+ */
+export function extendSwap(container: Container<any>) {
+  debug('extending japa context with container swap method')
+
+  TestContext.macro('swap', function (binding: any, fake: any) {
+    const activeTest = getActiveTest()
+    if (!activeTest) throw new Error('Cannot use "swap" outside of a Japa test')
+
+    container.swap(binding, typeof fake === 'function' ? fake : () => fake)
+
+    activeTest.cleanup(() => container.restore(binding))
+
+    return fake
+  })
+}

--- a/src/types/extended.ts
+++ b/src/types/extended.ts
@@ -15,6 +15,8 @@ import type {
   GetRoutesForMethod,
   RouteBuilderArguments,
 } from '@adonisjs/core/types/http'
+import { type AbstractConstructor } from '@adonisjs/core/types/common'
+import { type BindingResolver } from '@adonisjs/core/types/container'
 
 declare module '@japa/runner/core' {
   /**
@@ -24,6 +26,26 @@ declare module '@japa/runner/core' {
    * for route URL generation and REPL access during tests.
    */
   export interface TestContext {
+    /**
+     * Swap a container binding with a fake implementation for the
+     * duration of the test. The original binding is automatically
+     * restored after the test completes.
+     *
+     * @example
+     * ```ts
+     * test('sends welcome email', async ({ swap }) => {
+     *   swap(Mailer, new FakeMailer())
+     *
+     *   await userService.register({ email: 'joe@example.com' })
+     *   fakeMailer.assertSent('joe@example.com')
+     * })
+     * ```
+     */
+    swap<Binding extends AbstractConstructor<any>>(
+      binding: Binding,
+      fake: InstanceType<Binding> | BindingResolver<any, InstanceType<Binding>>
+    ): InstanceType<Binding>
+
     /**
      * Creates a URL for a pre-registered route using AdonisJS router.
      *

--- a/tests/swap.spec.ts
+++ b/tests/swap.spec.ts
@@ -1,0 +1,135 @@
+/*
+ * @japa/plugin-adonisjs
+ *
+ * (c) Japa
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { getActiveTest, test } from '@japa/runner'
+import type { ApplicationService } from '@adonisjs/core/types'
+import { Emitter, Refiner, Runner, Suite, Test, TestContext } from '@japa/runner/core'
+
+import { extendSwap } from '../src/swap.ts'
+import { bootApplication } from '../tests_helpers/bootstrap.ts'
+
+class Mailer {
+  send(_to: string, _body: string) {}
+}
+
+class FakeMailer extends Mailer {
+  sent: Array<{ to: string; body: string }> = []
+
+  override send(to: string, body: string) {
+    this.sent.push({ to, body })
+  }
+}
+
+test.group('Swap', (group) => {
+  let app: ApplicationService
+
+  group.setup(async () => {
+    app = await bootApplication('web')
+  })
+
+  test('swap a container binding within a test', async ({ assert }) => {
+    const refiner = new Refiner()
+    const emitter = new Emitter()
+    const runner = new Runner(emitter)
+    const suite = new Suite('Unit', emitter, refiner)
+    const t = new Test('sample test', (self) => new TestContext(self), emitter, refiner)
+
+    app.container.bind(Mailer, () => new Mailer())
+    extendSwap(app.container)
+
+    const fakeMailer = new FakeMailer()
+
+    t.run(async ({ swap }) => {
+      swap(Mailer, fakeMailer)
+      const resolved = await app.container.make(Mailer)
+      assert.strictEqual(resolved, fakeMailer)
+    })
+
+    runner.add(suite)
+    suite.add(t)
+    await runner.start()
+    await runner.exec()
+    await runner.end()
+
+    const summary = runner.getSummary()
+    assert.isFalse(summary.hasError)
+  })
+
+  test('restore the binding after the test completes', async ({ assert, cleanup }) => {
+    app.container.bind(Mailer, () => new Mailer())
+    extendSwap(app.container)
+
+    const fakeMailer = new FakeMailer()
+    const { swap } = new TestContext({} as any)
+    swap(Mailer, fakeMailer)
+
+    const swapped = await app.container.make(Mailer)
+    assert.strictEqual(swapped, fakeMailer)
+
+    /**
+     * getActiveTest().cleanup() registered the restore.
+     * After this test ends, `container.restore(Mailer)` will run.
+     * We can verify by manually calling restore here.
+     */
+    app.container.restore(Mailer)
+    const restored = await app.container.make(Mailer)
+    assert.isFalse(restored instanceof FakeMailer)
+
+    cleanup(() => app.container.restore(Mailer))
+  })
+
+  test('swap with a factory function', async ({ assert }) => {
+    const refiner = new Refiner()
+    const emitter = new Emitter()
+    const runner = new Runner(emitter)
+    const suite = new Suite('Unit', emitter, refiner)
+    const t = new Test('sample test', (self) => new TestContext(self), emitter, refiner)
+
+    app.container.bind(Mailer, () => new Mailer())
+    extendSwap(app.container)
+
+    t.run(async ({ swap }) => {
+      swap(Mailer, () => new FakeMailer())
+      const resolved = await app.container.make(Mailer)
+      assert.instanceOf(resolved, FakeMailer)
+    })
+
+    runner.add(suite)
+    suite.add(t)
+    await runner.start()
+    await runner.exec()
+    await runner.end()
+
+    const summary = runner.getSummary()
+    assert.isFalse(summary.hasError)
+  })
+
+  test('swap via a userland helper using getActiveTest', async ({ assert, cleanup }) => {
+    app.container.bind(Mailer, () => new Mailer())
+    extendSwap(app.container)
+
+    /**
+     * Simulates a userland helper that wraps swap
+     * e.g. in tests_helpers/fakes.ts
+     */
+    function swapMailer() {
+      const t = getActiveTest()!
+      const fake = new FakeMailer()
+      t.context.swap(Mailer, fake)
+
+      return fake
+    }
+
+    const fake = swapMailer()
+    const resolved = await app.container.make(Mailer)
+    assert.strictEqual(resolved, fake)
+
+    cleanup(() => app.container.restore(Mailer))
+  })
+})

--- a/tests/swap.spec.ts
+++ b/tests/swap.spec.ts
@@ -11,7 +11,7 @@ import { getActiveTest, test } from '@japa/runner'
 import type { ApplicationService } from '@adonisjs/core/types'
 import { Emitter, Refiner, Runner, Suite, Test, TestContext } from '@japa/runner/core'
 
-import { extendSwap } from '../src/swap.ts'
+import { extendSwap, useFake } from '../src/swap.ts'
 import { bootApplication } from '../tests_helpers/bootstrap.ts'
 
 class Mailer {
@@ -128,6 +128,19 @@ test.group('Swap', (group) => {
 
     const fake = swapMailer()
     const resolved = await app.container.make(Mailer)
+    assert.strictEqual(resolved, fake)
+
+    cleanup(() => app.container.restore(Mailer))
+  })
+
+  test('swap via useFake standalone helper', async ({ assert, cleanup }) => {
+    app.container.bind(Mailer, () => new Mailer())
+    extendSwap(app.container)
+
+    const fake = useFake(Mailer, new FakeMailer())
+    const resolved = await app.container.make(Mailer)
+
+    assert.instanceOf(fake, FakeMailer)
     assert.strictEqual(resolved, fake)
 
     cleanup(() => app.container.restore(Mailer))


### PR DESCRIPTION
Quick QOL helper. Adds a swap method on japa's TestContext that lets you replace a container binding with a fake for the duration of a test. binding gets auto-restored after the test completes via cleanup.

```ts
// via test ctx
test('sends welcome email', async ({ swap }) => {
  const fakeMailer = new FakeMailer()
  swap(Mailer, fakeMailer)

  await userService.register({ email: 'joe@example.com' })
  fakeMailer.assertSent('joe@example.com')
})

// via useFake
import { useFake } from '@japa/plugin-adonisjs/helpers'

test('sends welcome email', async () => {
  useFake(Mailer, new FakeMailer())

  await userService.register({ email: 'joe@example.com' })
  fakeMailer.assertSent('joe@example.com')
})
```

So i've been copy/pasting a little useFake helper across all my projects for a while now

it's pretty elegant compared to manually doing container.swap + container.restore in every single test, you just call it and forget about cleanup. felt like it deserved to live in the core properly instead of being a personal snippet